### PR TITLE
Use existing m_currentMap when already in collection

### DIFF
--- a/SC/DProfileReader.cs
+++ b/SC/DProfileReader.cs
@@ -360,9 +360,11 @@ namespace SCJMapper_V2.SC
               } );
               if ( !String.IsNullOrEmpty( item ) ) {
                 // finally.... it is a valid actionmap
-                m_currentMap = new ActionMap( );
-                m_currentMap.name = mapName;
-                m_aMap.Add( mapName, m_currentMap ); // add to our inventory
+                if( !m_aMap.TryGetValue( mapName, out m_currentMap ) ) {
+                    m_currentMap = new ActionMap();
+                    m_currentMap.name = mapName;
+                    m_aMap.Add( mapName, m_currentMap ); // add to our inventory
+                }
                 m_state = EState.inActionMap; // now we are in and processing the map
               }
             }


### PR DESCRIPTION
Hi,
Just a small commit to fix current 2.6.2 loading issues. Fixes https://github.com/SCToolsfactory/SCJMapper-V2/issues/51 .

`Dump XML` still doesn't work correctly, but I can at least get the program to load existing XML files.

Note that the project does not work with VS2017 out of the box, but this is probably something for another pull request.

Cheers!